### PR TITLE
Fix test setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ Makefile
 Testing/
 _deps/
 *.cmake
+DartConfiguration.tcl
+lib/
+parser
+test/configuration_test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,4 +15,4 @@ set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
 
 add_executable(parser src/main.cpp)
-
+add_subdirectory(test)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,7 +4,7 @@ enable_testing()
 
 add_executable(
         configuration_test
-        test/configuration_test.cpp
+        configuration_test.cpp
 )
 target_link_libraries(
         configuration_test


### PR DESCRIPTION
Fixes test setup so that CTest actually has tests configured. Adds `test` as a subdir in the root CMake file and fixes the test CMake file to properly include tests configured.

# Review checklist
-   [x] Contains enough appropriate tests
-   [x] If PR includes UI updates/additions, its description has screenshots
-   [x] Behavior is as expected
-   [x] Clean, well structured code
