### PR TITLE
Add support for nested closures

### DIFF
--- a/src/parser/ast/ClosureSimplifierVisitor.cpp
+++ b/src/parser/ast/ClosureSimplifierVisitor.cpp
@@ -27,12 +27,19 @@ static bool visitRules(Visitor<bool>* context, const std::shared_ptr<Node>& node
         throw std::runtime_error(what.str());
     }
 
+    int initialNumberOfRules = node->getChildren().size();
+
     for (auto& child: node->getChildren()) {
         closureSimplifier->visit(child);
     }
 
     for (auto& rule: closureSimplifier->getNewRules()) {
         node->addChild(rule);
+    }
+
+    if (initialNumberOfRules != node->getChildren().size()) {
+        closureSimplifier->clearNewRules();
+        return closureSimplifier->visit(node);
     }
 
     return true;
@@ -119,6 +126,10 @@ std::vector<std::shared_ptr<Node>> ClosureSimplifierVisitor::getNewRules() {
 
 void ClosureSimplifierVisitor::addNewRule(const std::shared_ptr<Node> &node) {
     this->newRules.push_back(node);
+}
+
+void ClosureSimplifierVisitor::clearNewRules() {
+    this->newRules.clear();
 }
 
 std::vector<std::shared_ptr<Node>> ClosureSimplifierVisitor::getNewBlocks() {

--- a/src/parser/ast/ClosureSimplifierVisitor.h
+++ b/src/parser/ast/ClosureSimplifierVisitor.h
@@ -17,6 +17,7 @@ public:
 
     std::vector<std::shared_ptr<Node>> getNewRules();
     void addNewRule(const std::shared_ptr<Node>& node);
+    void clearNewRules();
 
     std::vector<std::shared_ptr<Node>> getNewBlocks();
     void addNewBlock(const std::shared_ptr<Node>& node);


### PR DESCRIPTION
Closes #20 
Forces `ClosureSimplifierVisitor` to keep visiting all rules until no more rules are created - this ensures that no nested closure was brought up upon the last iteration and left unchecked.

# Review checklist
-   [ ] Contains enough appropriate tests
-   [x] If PR includes UI updates/additions, its description has screenshots
-   [x] Behavior is as expected
-   [x] Clean, well structured code
