### PR TITLE
Add annotation transfer to final parsing tree

### DIFF
--- a/src/parser/grammar/GrammarBuilder.cpp
+++ b/src/parser/grammar/GrammarBuilder.cpp
@@ -162,23 +162,24 @@ void GrammarBuilder::computeSets() {
 Parser GrammarBuilder::buildGrammar() {
     for (const auto& setOfRules: this->rules) {
         std::shared_ptr<NonTerminal> nonTerminal = this->nonTerminals.find(setOfRules.first)->second;
-        for (const auto& rule: setOfRules.second) {
-            for (const auto& terminalSymbol: GrammarBuilder::computeFirst(rule)) {
+        auto annotationsVec = this->annotations.find(setOfRules.first)->second;
+        for (int i = 0; i < setOfRules.second.size(); i++) {
+            for (const auto& terminalSymbol: GrammarBuilder::computeFirst(setOfRules.second[i])) {
                 auto terminal = std::dynamic_pointer_cast<Terminal>(terminalSymbol);
 
                 if (terminal) {
-                    nonTerminal->addToRule(*terminal, rule);
+                    nonTerminal->addToRule(*terminal, setOfRules.second[i], annotationsVec[i]);
                 } else {
                     throw std::runtime_error("Wrong type of symbol passed to FIRST set.");
                 }
             }
 
-            if (GrammarBuilder::isNullable(rule)) {
+            if (GrammarBuilder::isNullable(setOfRules.second[i])) {
                 for (const auto& terminalSymbol: nonTerminal->getFollow()) {
                     auto terminal = std::dynamic_pointer_cast<Terminal>(terminalSymbol);
 
                     if (terminal) {
-                        nonTerminal->addToRule(*terminal, rule);
+                        nonTerminal->addToRule(*terminal, setOfRules.second[i], annotationsVec[i]);
                     } else {
                         throw std::runtime_error("Wrong type of symbol passed to FIRST set.");
                     }

--- a/src/parser/grammar/NonTerminal.h
+++ b/src/parser/grammar/NonTerminal.h
@@ -21,12 +21,16 @@ public:
     void addToRule(const Terminal& first, const std::shared_ptr<Terminal>& expansion);
     void addToRule(const Terminal& first, const std::shared_ptr<NonTerminal>& expansion);
     void addToRule(const Terminal &first, const std::vector<std::shared_ptr<Symbol>>& expansion);
+    void addToRule(const Terminal &first, const std::vector<std::shared_ptr<Symbol>>& expansion,
+                   const std::vector<std::map<std::string, std::string>>& annotations);
     std::vector<std::shared_ptr<Symbol>> getRule(const Terminal& first) const;
+    std::vector<std::map<std::string, std::string>> getAnnotation(const Terminal& first) const;
 
     bool isNullable() const override;
     void setNullable(bool nullable);
 private:
     std::map<Terminal, std::vector<std::shared_ptr<Symbol>>> rules;
+    std::map<Terminal, std::vector<std::map<std::string, std::string>>> annotations;
     bool nullable = false;
 };
 

--- a/src/parser/utils.cpp
+++ b/src/parser/utils.cpp
@@ -12,6 +12,7 @@ std::string SYMBOL_NAME = "symbol_name";
 std::string CLOSURE = "closure";
 std::string REGEX_LITERAL = "regex";
 std::string BEFORE_START_NAME = "SStart";
+std::string LAST_TOKEN = "last_token";
 std::string INTERMEDIATE_NON_TERMINAL_PATTERN = "Intermediate_NonTerminal_";
 
-std::unordered_set<std::string> KEYWORDS = std::unordered_set<std::string>({CONSUMED_TOKEN, SYMBOL_NAME, CLOSURE, REGEX_LITERAL, BEFORE_START_NAME});
+std::unordered_set<std::string> KEYWORDS = std::unordered_set<std::string>({CONSUMED_TOKEN, SYMBOL_NAME, CLOSURE, REGEX_LITERAL, BEFORE_START_NAME, LAST_TOKEN});

--- a/src/parser/utils.h
+++ b/src/parser/utils.h
@@ -17,6 +17,7 @@ extern std::string CLOSURE;
 extern std::string INTERMEDIATE_NON_TERMINAL_PATTERN;
 extern std::string REGEX_LITERAL;
 extern std::string BEFORE_START_NAME;
+extern std::string LAST_TOKEN;
 extern std::unordered_set<std::string> KEYWORDS;
 
 #endif //PARSER_UTILS_H


### PR DESCRIPTION
Closes #38 
Transfers grammar annotations to the final parsing tree. Retrieves last token consumed in case it is requested by the grammar.

# Review checklist
-   [ ] Contains enough appropriate tests
-   [ ] If PR includes UI updates/additions, its description has screenshots
-   [ ] Behavior is as expected
-   [ ] Clean, well structured code
